### PR TITLE
Use properties to configure the number of persons to migrate

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/migrering/domain/common/RepositoryInterface.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/domain/common/RepositoryInterface.kt
@@ -7,16 +7,5 @@ import org.springframework.data.repository.NoRepositoryBean
  * På grunn av att vi setter id's på våre entitetet så prøver spring å oppdatere våre entiteter i stedet for å ta insert
  */
 @NoRepositoryBean
-interface RepositoryInterface<T, ID> : CrudRepository<T, ID> {
-
-    @Deprecated("Støttes ikke, bruk insert/update")
-    override fun <S : T> save(entity: S): S {
-        error("Not implemented - Use InsertUpdateRepository - insert/update")
-    }
-
-    @Deprecated("Støttes ikke, bruk insertAll/updateAll")
-    override fun <S : T> saveAll(entities: Iterable<S>): Iterable<S> {
-        error("Not implemented - Use InsertUpdateRepository - insertAll/updateAll")
-    }
-}
+interface RepositoryInterface<T, ID> : CrudRepository<T, ID>
 

--- a/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringService.kt
@@ -17,7 +17,8 @@ class HentSakTilMigreringService(
     val infotrygdClient: InfotrygdClient,
     val taskRepository: TaskRepository,
     val migrertsakRepository: MigrertsakRepository,
-    @Value("\${migrering.aktivert:false}") val migreringAktivert: Boolean
+    @Value("\${migrering.aktivert:false}") val migreringAktivert: Boolean,
+    @Value("\${migrering.antallPersoner}") val antallPersoner: Int,
 ) {
 
     @Scheduled(cron = "0 0 8 * * ?", zone = "Europe/Oslo")
@@ -49,14 +50,13 @@ class HentSakTilMigreringService(
                 taskRepository.save(MigreringTask.opprettTask(MigreringTaskDto(person)))
                 antallPersonerMigrert++
             }
-            if (antallPersonerMigrert == MAX_ANTALL_PERSONER_SOM_SKAL_MIGRERES)
+            if (antallPersonerMigrert == antallPersoner)
                 break
         }
     }
 
     companion object {
         val Log = LoggerFactory.getLogger(HentSakTilMigreringService::class.java)
-        val MAX_ANTALL_PERSONER_SOM_SKAL_MIGRERES = 20
         val ANTALL_PERSONER_SOM_HENTES_FRA_INFOTRYGD = 100
     }
 }

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -4,8 +4,9 @@ BA_SAK_API_URL: https://familie-ba-sak.dev-fss-pub.nais.io/api
 FAMILIE_BA_INFOTRYGD_SCOPE: api://dev-fss.teamfamilie.familie-ba-infotrygd/.default
 FAMILIE_BA_INFOTRYGD_API_URL: https://familie-ba-infotrygd.dev-fss-pub.nais.io
 
-migrering.aktivert: true
-
+migrering:
+  aktivert: true
+  antallPersoner: 20
 
 no.nav.security.jwt:
   issuer.azuread:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,3 +57,7 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+
+migrering:
+  aktivert: false
+  antallPersoner: 20

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,4 +60,4 @@ no.nav.security.jwt:
 
 migrering:
   aktivert: false
-  antallPersoner: 20
+  antallPersoner: 1

--- a/src/test/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringServiceTest.kt
@@ -29,7 +29,8 @@ class HentSakTilMigreringServiceTest {
             infotrygdClientMock,
             taskRepositoryMock,
             migertsakRepository,
-            true
+            true,
+            20,
         ).hentSakTilMigrering()
 
         assertThat(tasker).hasSize(2)
@@ -51,7 +52,8 @@ class HentSakTilMigreringServiceTest {
             infotrygdClientMock,
             taskRepositoryMock,
             migertsakRepository,
-            true
+            true,
+            20,
         ).hentSakTilMigrering()
 
         verify(exactly = 0) { taskRepositoryMock.save(any()) }


### PR DESCRIPTION
Added a value in properties: migrering.antallPersoner to configure the number of persons