### PR TITLE
Går over til versjon 2 av endepunktet i InfotrygdClient.hentPersonerKlareForMigrering…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/migrering/integrasjoner/InfotrygdClient.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/integrasjoner/InfotrygdClient.kt
@@ -22,8 +22,8 @@ class InfotrygdClient @Autowired constructor(
     @Qualifier("azure") restOperations: RestOperations
 ) : AbstractRestClient(restOperations, "migrering.infotrygd") {
 
-    fun hentPersonerKlareForMigrering(migreringRequest: MigreringRequest): Set<String> {
-        val uri = URI.create("$infotrygdApiUri/infotrygd/barnetrygd/migrering")
+    fun hentPersonerKlareForMigrering(migreringRequest: MigreringRequest): MigreringResponse {
+        val uri = URI.create("$infotrygdApiUri/infotrygd/barnetrygd/migrering/v2")
         return try {
             postForEntity(uri, migreringRequest)
         } catch (ex: Exception) {
@@ -81,6 +81,11 @@ data class MigreringRequest(
     val undervalg: String,
     val maksAntallBarn: Int = 99,
     val minimumAlder: Int = 7,
+)
+
+data class MigreringResponse(
+    val personerKlarForMigrering: Set<String>,
+    val totalPages: Int
 )
 
 class StønadRequest(

--- a/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringService.kt
@@ -30,7 +30,7 @@ class HentSakTilMigreringService(
         var antallPersonerMigrert = 0
         var startSide = 0
         while (antallPersonerMigrert < antallPersoner) {
-            val personerForMigrering = infotrygdClient.hentPersonerKlareForMigrering(
+            val (personerForMigrering, totalPages) = infotrygdClient.hentPersonerKlareForMigrering(
                 MigreringRequest(
                     page = startSide,
                     size = ANTALL_PERSONER_SOM_HENTES_FRA_INFOTRYGD,
@@ -42,12 +42,10 @@ class HentSakTilMigreringService(
             )
             Log.info("Fant ${personerForMigrering.size} personer for migrering på side $startSide")
             secureLogger.info("Resultat fra infotrygd: $personerForMigrering")
-            if (personerForMigrering.isEmpty()) break
+            if (personerForMigrering.isNotEmpty())
+                antallPersonerMigrert = oppretteEllerSkipMigrering(personerForMigrering, antallPersonerMigrert, antallPersoner)
 
-            antallPersonerMigrert = oppretteEllerSkipMigrering(personerForMigrering, antallPersonerMigrert, antallPersoner)
-            if (antallPersonerMigrert < antallPersoner) {
-                startSide = startSide.inc()
-            }
+            if (++startSide == totalPages) break
         }
 
         return "Migrerte $antallPersoner"

--- a/src/test/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringServiceTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ba.migrering.domain.Migrertsak
 import no.nav.familie.ba.migrering.domain.MigrertsakRepository
 import no.nav.familie.ba.migrering.integrasjoner.InfotrygdClient
 import no.nav.familie.ba.migrering.integrasjoner.MigreringRequest
+import no.nav.familie.ba.migrering.integrasjoner.MigreringResponse
 import no.nav.familie.ba.migrering.services.HentSakTilMigreringService.Companion.ANTALL_PERSONER_SOM_HENTES_FRA_INFOTRYGD
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -46,7 +47,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns personIdenter.toSet()
+        } returns MigreringResponse(personIdenter.toSet(), 2)
         every {
             infotrygdClientMock.hentPersonerKlareForMigrering(
                 MigreringRequest(
@@ -58,7 +59,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns emptySet()
+        } returns MigreringResponse(emptySet(), 2)
         val tasker = mutableListOf<Task>()
         every { taskRepositoryMock.save(capture(tasker)) } returns Task(type = "", payload = "")
         every { migertsakRepository.findByPersonIdent(any()) } returns emptyList()
@@ -86,7 +87,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns setOf(personIdent)
+        } returns MigreringResponse(setOf(personIdent), 2)
         every {
             infotrygdClientMock.hentPersonerKlareForMigrering(
                 MigreringRequest(
@@ -98,7 +99,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns emptySet()
+        } returns MigreringResponse(emptySet(), 2)
         every { migertsakRepository.findByPersonIdent(personIdent) } returns listOf(
             Migrertsak()
         )
@@ -125,7 +126,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns arrayOf("1", "2", "3").toSet()
+        } returns MigreringResponse(arrayOf("1", "2", "3").toSet(), 3)
         every {
             infotrygdClientMock.hentPersonerKlareForMigrering(
                 MigreringRequest(
@@ -137,7 +138,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns arrayOf("4", "5", "6", "7", "8").toSet()
+        } returns MigreringResponse(arrayOf("4", "5", "6", "7", "8").toSet(), 3)
         every {
             infotrygdClientMock.hentPersonerKlareForMigrering(
                 MigreringRequest(
@@ -149,7 +150,7 @@ class HentSakTilMigreringServiceTest {
                     HentSakTilMigreringService.MINIMUM_ALDER,
                 )
             )
-        } returns arrayOf("9", "10", "11", "12", "13").toSet()
+        } returns MigreringResponse(arrayOf("9", "10", "11", "12", "13").toSet(), 3)
         val tasker = mutableListOf<Task>()
         every { taskRepositoryMock.save(capture(tasker)) } returns Task(type = "", payload = "")
         every { migertsakRepository.findByPersonIdent(any()) } returns emptyList()


### PR DESCRIPTION
… som returnerer totalPages i tillegg, og bruker den til å holde migrer-loop'en gående selv om det skulle dukke opp en tom side underveis.