### PR TITLE
Automatisk rekjøring av feilede migreringer som følge av åpen sak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringScheduler.kt
@@ -44,9 +44,10 @@ class HentSakTilMigreringScheduler(
 
     @Scheduled(cron = "0 0 17 * * MON-FRI", zone = "Europe/Oslo")
     fun rekjørMigreringerMedFeiltypeÅpenSak() {
-        Log.info("Trigger automatisk rekjøring av migreringer som feilet pga. åpen sak i Infotrygd ")
+        Log.info("Trigger automatisk rekjøring av migreringer som feilet pga. åpen sak i Infotrygd, samt ukjente feil")
         hentSakTilMigreringService.rekjørMigreringerMedFeiltype(MigreringsfeilType.ÅPEN_SAK_INFOTRYGD.name)
         hentSakTilMigreringService.rekjørMigreringerMedFeiltype(MigreringsfeilType.ÅPEN_SAK_TIL_BESLUTNING_I_INFOTRYGD.name)
+        hentSakTilMigreringService.rekjørMigreringerMedFeiltype(MigreringsfeilType.UKJENT.name)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/migrering/services/HentSakTilMigreringScheduler.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ba.migrering.services
 
+import no.nav.familie.ba.migrering.rest.MigreringsfeilType
 import no.nav.familie.ba.migrering.services.Kategori.ORDINÆR_DELT_BOSTED
 import no.nav.familie.ba.migrering.services.Kategori.UTVIDET
 import no.nav.familie.ba.migrering.services.Kategori.UTVIDET_DELT_BOSTED
@@ -41,6 +42,12 @@ class HentSakTilMigreringScheduler(
         }
     }
 
+    @Scheduled(cron = "0 0 17 * * MON-FRI", zone = "Europe/Oslo")
+    fun rekjørMigreringerMedFeiltypeÅpenSak() {
+        Log.info("Trigger automatisk rekjøring av migreringer som feilet pga. åpen sak i Infotrygd ")
+        hentSakTilMigreringService.rekjørMigreringerMedFeiltype(MigreringsfeilType.ÅPEN_SAK_INFOTRYGD.name)
+        hentSakTilMigreringService.rekjørMigreringerMedFeiltype(MigreringsfeilType.ÅPEN_SAK_TIL_BESLUTNING_I_INFOTRYGD.name)
+    }
 
     companion object {
         val Log = LoggerFactory.getLogger(HentSakTilMigreringScheduler::class.java)


### PR DESCRIPTION
Scheduled jobb som henter og rekjører alle åpne saker med feiltype

ÅPEN_SAK_INFOTRYGD / ÅPEN_SAK_TIL_BESLUTNING_I_INFOTRYGD

hver ukedag kl. 17.00